### PR TITLE
feat: Habilitar dibujo táctil en el lienzo

### DIFF
--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -289,6 +289,9 @@ export const ImageCanvas: React.FC = () => {
           onMouseDown={handleMouseDown}
           onMousemove={handleMouseMove}
           onMouseup={handleMouseUp}
+          onTouchStart={handleMouseDown}
+          onTouchMove={handleMouseMove}
+          onTouchEnd={handleMouseUp}
           style={{ 
             cursor: selectedTool === 'mask' ? 'crosshair' : 'default' 
           }}


### PR DESCRIPTION
Añade los manejadores de eventos `onTouchStart`, `onTouchMove` y `onTouchEnd` al componente `Stage` de `react-konva`.

Estos eventos se asignan a las funciones de manejo de mouse existentes para permitir que la funcionalidad de dibujo de máscaras funcione en dispositivos con pantalla táctil (por ejemplo, Android) sin duplicar la lógica de dibujo.