### PR TITLE
[codex] Fix Gemini model name and ad-block white screen

### DIFF
--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -43,7 +43,7 @@ export class GeminiService {
       }
 
       const response = await genAI.models.generateContent({
-        model: "gemini-2.5-flash-image-preview",
+        model: "gemini-2.5-flash-image",
         contents,
       });
 
@@ -96,7 +96,7 @@ export class GeminiService {
       }
 
       const response = await genAI.models.generateContent({
-        model: "gemini-2.5-flash-image-preview",
+        model: "gemini-2.5-flash-image",
         contents,
       });
 
@@ -141,7 +141,7 @@ Only segment the specific object or region requested. The mask should be a binar
       ];
 
       const response = await genAI.models.generateContent({
-        model: "gemini-2.5-flash-image-preview",
+        model: "gemini-2.5-flash-image",
         contents: prompt,
       });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,4 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  optimizeDeps: {
-    exclude: ['lucide-react'],
-  },
 });


### PR DESCRIPTION
## Summary
- Updates the Gemini image model name from the preview identifier to the GA identifier.
- Removes the Vite optimizeDeps exclusion that caused ad-blockers to block lucide icon chunks and trigger a white screen.

## Validation
- `npm ci`
- `npm run build`

## Notes
- Opened from a fork because upstream is read-only for this account.
- Left local `.infisical.json` untracked; it is not part of this PR.
